### PR TITLE
Change default repeat time from 5 mins to 59 mins past the hour

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ ftx offers --subaccount Idle
 
 ### Repeating commands and auto-compounding
 
-Any command can easily be repeated at specified intervals via the inbuilt command scheduler and will keep running until manually aborted. The default schedule is 'at 5 minutes past every hour' because FTX variable lending rates and balances are updated hourly.
+Any command can easily be repeated at specified intervals via the inbuilt command scheduler and will keep running until manually aborted. The default schedule is 'at 59 minutes past every hour' because FTX variable lending rates and balances are updated hourly.
 
 ```sh
 # Auto-compound all lendable currencies with no minimum rate.

--- a/bin/runCommand.js
+++ b/bin/runCommand.js
@@ -5,8 +5,8 @@ import { Commands } from '../src/commands/index.js';
 import { CONFIG } from '../src/config/index.js';
 import { handleError } from './handleError.js';
 
-// Repeat at 5 minutes past every hour.
-const DEFAULT_CRON_EXPRESSION = '5 * * * *';
+// Repeat at 55 minutes past every hour.
+const DEFAULT_CRON_EXPRESSION = '59 * * * *';
 
 function getGlobalOptions() {
   const inlineGlobalOptions = program.opts();


### PR DESCRIPTION
Reasons for change:
- It often takes longer than 5 minutes after the hour for interest to be credited even though the timestamp is on the hour, so repeating the command at XX:05 may not increase the lent amount for the next period.
- Interest is paid at the start of the hour. Eg. if you begin lending at 10:50, you can instantly stop lending and unlock funds until 10:59:59; at 11:00, interest is paid and funds are locked until 12:00. However, even if you are able to unlock funds instantly, margin is reduced regardless, so it is optimal to send the command as last as possible.